### PR TITLE
Bugfix: Search on string with dot was not possible

### DIFF
--- a/pkg/sql/urlquery.go
+++ b/pkg/sql/urlquery.go
@@ -98,7 +98,7 @@ func (q *URLQuery) WhereQuery(index uint) (newIndex uint, query string, args []a
 			continue
 		}
 		for _, vv := range v {
-			vals := strings.Split(vv, ".")
+			vals := strings.SplitN(vv, ".", 2)
 			if len(vals) != 2 {
 				continue
 			}


### PR DESCRIPTION
This adds the ability to search on a term that contains a dot.

If you want to filter on something that contains a dot `.` the search term used to just be skipped. ie: `?level=eq.myspecial.thing.that.contains.dots`

But after this change it will filter on `myspecial.thing.that.contains.dots`